### PR TITLE
Moving 'extent' function and adding section heading for 'clustering'

### DIFF
--- a/docs/documentation.yml
+++ b/docs/documentation.yml
@@ -2,6 +2,7 @@ toc:
   - name: 'Basic Descriptive Statistics'
   - min
   - max
+  - extent
   - sum
   - sumSimple
   - quantile
@@ -80,6 +81,10 @@ toc:
       for instance, because each color will be represented equally.
   - ckmeans
   - equalIntervalBreaks
+  - name: 'Clustering'
+  - kMeansCluster
+  - silhouette
+  - silhouetteMetric
   - name: 'Utilities'
   - chunk
   - chiSquaredGoodnessOfFit


### PR DESCRIPTION
1.  Move `extent` to `basic descriptive statistics` section, since it seems a natural counterpart to `min` and `max`.
2.  Create a section heading for `kMeansClustering`, `silhouette`, and `silhouetteMetric`.